### PR TITLE
Fixed inheritance issue with ad report custom conversions

### DIFF
--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -317,7 +317,7 @@ class AccountsStream(ReportsStream):
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "account.json"
 
-class AdPerformanceReportConversionStats(GoogleAdsStream):
+class AdPerformanceReportConversionStats(ReportsStream):
     """Ad Performance Report Conversion Stats stream."""
     
     @property


### PR DESCRIPTION
## Description
AdPerformanceReportCustomConversions was inheriting from GoogleAdsStream which was incorrect. Changed the inheritance to ReportStream.