### PR TITLE
feat: Enhance video report streams with ad, channel, and video metada…

### DIFF
--- a/tap_googleads/schemas/video_report.json
+++ b/tap_googleads/schemas/video_report.json
@@ -13,6 +13,12 @@
       "video__id": {
         "type": ["string", "null"]
       },
+      "adGroupAd__ad__id": {
+        "type": ["string", "null"]
+      },
+      "adGroupAd__ad__name": {
+        "type": ["string", "null"]
+      },
       "metrics__clicks": {
         "type": ["number", "null"]
       },
@@ -55,6 +61,18 @@
       "segments__date": {
         "type": ["string", "null"],
         "format": "date"
+      },
+      "video__channelId": {
+        "type": ["string", "null"]
+      },
+      "video__title": {
+        "type": ["string", "null"]
+      },
+      "customer__descriptiveName": {
+        "type": ["string", "null"]
+      },
+      "video__durationMillis": {
+        "type": ["string", "null"]
       }
     }
   }


### PR DESCRIPTION
### Summary

This PR enhances the video reporting functionality in the Google Ads tap by:
- Adding additional metadata fields to the video report and custom conversions streams, including:
  - Ad ID (`adGroupAd__ad__id`)
  - Ad name (`adGroupAd__ad__name`)
  - Channel ID (`video__channelId`)
  - Video title (`video__title`)
  - Video duration in millis (`video__durationMillis`)
  - Customer descriptive name (`customer__descriptiveName`)
- Updating the GAQL queries and JSON schemas to support these new fields.
- Ensuring `video__id` is always set in the output, defaulting to `'noId'` if missing, for more robust downstream joins.
- Aligning primary keys between `video_report` and `video_report_custom_conversions` for easier post-pivot joins.

### Motivation

- Enables richer reporting and easier data analysis by including more video and ad metadata.
- Prevents join issues due to missing `video__id` values.
- Improves schema and data consistency across related streams.

### Testing

- Ran tap and confirmed new fields are present and populated.
- Verified that `video__id` is never missing, even when the source data is incomplete.